### PR TITLE
Add custom glyphs

### DIFF
--- a/src/libs.c
+++ b/src/libs.c
@@ -1,5 +1,5 @@
 /* Avalanche
- * (c) 2022-3 Chris Young
+ * (c) 2022-5 Chris Young
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
 #include <proto/button.h>
 #include <proto/checkbox.h>
 #include <proto/chooser.h>
+#include <proto/drawlist.h>
 #include <proto/fuelgauge.h>
 #include <proto/getfile.h>
 #include <proto/glyph.h>
@@ -162,6 +163,7 @@ CLASS_STRUCT(BitMap)
 CLASS_STRUCT(Button)
 CLASS_STRUCT(CheckBox)
 CLASS_STRUCT(Chooser)
+CLASS_STRUCT(DrawList)
 CLASS_STRUCT(FuelGauge)
 CLASS_STRUCT(GetFile)
 CLASS_STRUCT(Glyph)
@@ -232,6 +234,7 @@ BOOL libs_open(void)
 	CLASS_OPEN("gadgets/button.gadget",        41, Button,        BUTTON,      FALSE)
 	CLASS_OPEN("gadgets/checkbox.gadget",      41, CheckBox,      CHECKBOX,    FALSE)
 	CLASS_OPEN("gadgets/chooser.gadget",       45, Chooser,       CHOOSER,     TRUE)
+	CLASS_OPEN("images/drawlist.image",        41, DrawList,     DRAWLIST,   FALSE)
 	CLASS_OPEN("gadgets/fuelgauge.gadget",     41, FuelGauge,     FUELGAUGE,   FALSE)
 	CLASS_OPEN("gadgets/getfile.gadget",       41, GetFile,       GETFILE,     FALSE)
 	CLASS_OPEN("images/glyph.image",           41, Glyph,         GLYPH,       FALSE)
@@ -255,6 +258,7 @@ void libs_close(void)
 	CLASS_CLOSE(Button)
 	CLASS_CLOSE(CheckBox)
 	CLASS_CLOSE(Chooser)
+	CLASS_CLOSE(DrawList)
 	CLASS_CLOSE(FuelGauge)
 	CLASS_CLOSE(GetFile)
 	CLASS_CLOSE(Glyph)

--- a/src/libs.h
+++ b/src/libs.h
@@ -1,5 +1,5 @@
 /* Avalanche
- * (c) 2022-3 Chris Young
+ * (c) 2022-5 Chris Young
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@ extern Class *BitMapClass;
 extern Class *ButtonClass;
 extern Class *CheckBoxClass;
 extern Class *ChooserClass;
+extern Class *DrawListClass;
 extern Class *FuelGaugeClass;
 extern Class *GetFileClass;
 extern Class *GlyphClass;
@@ -41,6 +42,7 @@ extern Class *WindowClass;
 #define ButtonObj		NewObject(ButtonClass, NULL
 #define CheckBoxObj		NewObject(CheckBoxClass, NULL
 #define ChooserObj		NewObject(ChooserClass, NULL
+#define DrawListObj		NewObject(DrawListClass, NULL
 #define FuelGaugeObj	NewObject(FuelGaugeClass, NULL
 #define GetFileObj		NewObject(GetFileClass, NULL
 #define GlyphObj		NewObject(GlyphClass, NULL

--- a/src/win.c
+++ b/src/win.c
@@ -152,7 +152,7 @@ static struct List winlist;
 #define AVALANCHE_GLYPH_ROOT 800
 #define AVALANCHE_GLYPH_OPENDRAWER 801
 
-static struct DrawList opendrawer[] = {
+static struct DrawList dl_opendrawer[] = {
 	{DLST_LINE, 90, 60, 90, 90, 1},
 	{DLST_LINE, 90, 90, 10, 90, 1},
 	{DLST_LINE, 10, 90, 10, 60, 1},
@@ -168,6 +168,23 @@ static struct DrawList opendrawer[] = {
 
 	{DLST_END, 0, 0, 0, 0, 0},
 };
+
+static struct DrawList dl_archiveroot[] = {
+	{DLST_LINE, 10, 90, 60, 90, 1},
+	{DLST_LINE, 60, 90, 60, 40, 1},
+	{DLST_LINE, 60, 40, 10, 40, 1},
+	{DLST_LINE, 10, 40, 10, 90, 1},
+
+	{DLST_LINE, 60, 90, 90, 70, 1},
+	{DLST_LINE, 60, 40, 90, 20, 1},
+	{DLST_LINE, 10, 40, 40, 20, 1},
+
+	{DLST_LINE, 90, 70, 90, 20, 1},
+	{DLST_LINE, 90, 20, 40, 20, 1},
+
+	{DLST_END, 0, 0, 0, 0, 0},
+};
+
 
 /** Menu **/
 
@@ -325,16 +342,26 @@ static Object *get_glyph(ULONG glyph)
 					BITMAP_Width, 16, */
 				BitMapEnd;
 	} else {
-		if(glyph == AVALANCHE_GLYPH_OPENDRAWER) {
+		if((glyph == AVALANCHE_GLYPH_OPENDRAWER) ||
+			(glyph == AVALANCHE_GLYPH_ROOT)) {
+				
+			struct DrawList *dl = NULL;
+				
+			if(glyph == AVALANCHE_GLYPH_OPENDRAWER) {
+				dl = &dl_opendrawer;
+			} else {
+				dl = &dl_archiveroot;
+			}
+				
 			glyphobj = DrawListObj,
-					DRAWLIST_Directives, &opendrawer,
+					DRAWLIST_Directives, dl,
 					DRAWLIST_RefHeight, 100,
 					DRAWLIST_RefWidth, 100,
 					IA_Width, 16,
 					IA_Height, 16,
 				End;
 		} else {
-			if(glyph == AVALANCHE_GLYPH_ROOT) glyph = GLYPH_POPDRAWER;
+			if glyph = GLYPH_POPDRAWER;
 
 			glyphobj = GlyphObj,
 						GLYPH_Glyph, glyph,

--- a/src/win.c
+++ b/src/win.c
@@ -330,6 +330,8 @@ static Object *get_glyph(ULONG glyph)
 					DRAWLIST_Directives, &opendrawer,
 					DRAWLIST_RefHeight, 100,
 					DRAWLIST_RefWidth, 100,
+					IA_Width, 16,
+					IA_Height, 16,
 				End;
 		} else {
 			if(glyph == AVALANCHE_GLYPH_ROOT) glyph = GLYPH_POPDRAWER;

--- a/src/win.c
+++ b/src/win.c
@@ -148,12 +148,30 @@ static struct List winlist;
 #define fr_ArgList rf_ArgList
 #endif
 
+/** Glyphs **/
 #define AVALANCHE_GLYPH_ROOT 800
 #define AVALANCHE_GLYPH_OPENDRAWER 801
 
+static struct DrawList opendrawer[] = {
+	{DLST_LINE, 90, 60, 90, 90, 1},
+	{DLST_LINE, 90, 90, 10, 90, 1},
+	{DLST_LINE, 10, 90, 10, 60, 1},
+	{DLST_LINE, 10, 60, 90, 60, 1},
+	{DLST_LINE, 90, 60, 70, 30, 1},
+	{DLST_LINE, 70, 30, 30, 30, 1},
+	{DLST_LINE, 30, 30, 10, 60, 1},
+	{DLST_LINE, 30, 30, 20, 30, 1},
+	{DLST_LINE, 20, 30, 20, 50, 1},
+
+	{DLST_LINE, 70, 30, 80, 30, 1},
+	{DLST_LINE, 80, 30, 80, 50, 1},
+
+	{DLST_END, 0, 0, 0, 0, 0},
+};
+
 /** Menu **/
 
-struct NewMenu menu[] = {
+static struct NewMenu menu[] = {
 	{NM_TITLE,  NULL,           0,  0, 0, 0,}, // 0 Project
 	{NM_ITEM,   NULL,         "N", 0, 0, 0,}, // 0 New archive
 	{NM_ITEM,   NULL,         "+", 0, 0, 0,}, // 1 New window
@@ -308,27 +326,6 @@ static Object *get_glyph(ULONG glyph)
 				BitMapEnd;
 	} else {
 		if(glyph == AVALANCHE_GLYPH_OPENDRAWER) {
-			struct DrawList opendrawer[] = {
-				{DLST_LINESIZE, 0, 0, 0, 0, 0xff},	
-				{DLST_LINEPAT, 0, 0, 0, 0, 0xff},
-								
-				{DLST_LINE, 90, 60, 90, 90, 1},
-				{DLST_LINE, 90, 90, 10, 90, 1},
-				{DLST_LINE, 10, 90, 10, 60, 1},
-				{DLST_LINE, 10, 60, 90, 60, 1},
-				{DLST_LINE, 90, 60, 70, 30, 1},
-				{DLST_LINE, 70, 30, 30, 30, 1},
-				{DLST_LINE, 30, 30, 10, 60, 1},
-				
-				{DLST_LINE, 30, 30, 20, 30, 1},
-				{DLST_LINE, 20, 30, 20, 50, 1},
-
-				{DLST_LINE, 70, 30, 80, 30, 1},
-				{DLST_LINE, 80, 30, 80, 50, 1},
-			
-				{DLST_END, 0, 0, 0, 0, 0},
-			};
-	
 			glyphobj = DrawListObj,
 					DRAWLIST_Directives, &opendrawer,
 					DRAWLIST_RefHeight, 100,

--- a/src/win.c
+++ b/src/win.c
@@ -309,8 +309,8 @@ static Object *get_glyph(ULONG glyph)
 	} else {
 		if(glyph == AVALANCHE_GLYPH_OPENDRAWER) {
 			struct DrawList opendrawer[] = {
-				{DLST_LINESIZE, 0, 0, 0, 0, 1},	
-				{DLST_LINEPAT, 0, 0, 0, 0, 1},
+				{DLST_LINESIZE, 0, 0, 0, 0, 0xff},	
+				{DLST_LINEPAT, 0, 0, 0, 0, 0xff},
 								
 				{DLST_LINE, 9, 6, 9, 9, 1},
 				{DLST_LINE, 9, 9, 1, 9, 1},

--- a/src/win.c
+++ b/src/win.c
@@ -166,6 +166,8 @@ static struct DrawList dl_opendrawer[] = {
 	{DLST_LINE, 70, 30, 80, 30, 1},
 	{DLST_LINE, 80, 30, 80, 50, 1},
 
+	{DLST_LINE, 40, 75, 60, 75, 1},
+
 	{DLST_END, 0, 0, 0, 0, 0},
 };
 
@@ -181,6 +183,8 @@ static struct DrawList dl_archiveroot[] = {
 
 	{DLST_LINE, 90, 70, 90, 20, 1},
 	{DLST_LINE, 90, 20, 40, 20, 1},
+
+	{DLST_LINE, 35, 40, 65, 20, 1},
 
 	{DLST_END, 0, 0, 0, 0, 0},
 };

--- a/src/win.c
+++ b/src/win.c
@@ -312,27 +312,27 @@ static Object *get_glyph(ULONG glyph)
 				{DLST_LINESIZE, 0, 0, 0, 0, 0xff},	
 				{DLST_LINEPAT, 0, 0, 0, 0, 0xff},
 								
-				{DLST_LINE, 9, 6, 9, 9, 1},
-				{DLST_LINE, 9, 9, 1, 9, 1},
-				{DLST_LINE, 1, 9, 1, 6, 1},
-				{DLST_LINE, 1, 6, 9, 6, 1},
-				{DLST_LINE, 9, 6, 7, 3, 1},
-				{DLST_LINE, 7, 3, 3, 3, 1},
-				{DLST_LINE, 3, 3, 1, 6, 1},
+				{DLST_LINE, 90, 60, 90, 90, 1},
+				{DLST_LINE, 90, 90, 10, 90, 1},
+				{DLST_LINE, 10, 90, 10, 60, 1},
+				{DLST_LINE, 10, 60, 90, 60, 1},
+				{DLST_LINE, 90, 60, 70, 30, 1},
+				{DLST_LINE, 70, 30, 30, 30, 1},
+				{DLST_LINE, 30, 30, 10, 60, 1},
 				
-				{DLST_LINE, 3, 3, 2, 3, 1},
-				{DLST_LINE, 2, 3, 2, 5, 1},
+				{DLST_LINE, 30, 30, 20, 30, 1},
+				{DLST_LINE, 20, 30, 20, 50, 1},
 
-				{DLST_LINE, 7, 3, 8, 3, 1},
-				{DLST_LINE, 8, 3, 8, 5, 1},
+				{DLST_LINE, 70, 30, 80, 30, 1},
+				{DLST_LINE, 80, 30, 80, 50, 1},
 			
 				{DLST_END, 0, 0, 0, 0, 0},
 			};
 	
 			glyphobj = DrawListObj,
 					DRAWLIST_Directives, &opendrawer,
-					DRAWLIST_RefHeight, 10,
-					DRAWLIST_RefWidth, 10,
+					DRAWLIST_RefHeight, 100,
+					DRAWLIST_RefWidth, 100,
 				End;
 		} else {
 			if(glyph == AVALANCHE_GLYPH_ROOT) glyph = GLYPH_POPDRAWER;

--- a/src/win.c
+++ b/src/win.c
@@ -33,6 +33,7 @@
 
 #include <proto/bitmap.h>
 #include <proto/button.h>
+#include <proto/drawlist.h>
 #include <proto/getfile.h>
 #include <proto/glyph.h>
 #include <proto/label.h>
@@ -45,6 +46,7 @@
 #include <gadgets/getfile.h>
 #include <gadgets/listbrowser.h>
 #include <images/bitmap.h>
+#include <images/drawlist.h>
 #include <images/glyph.h>
 #include <images/label.h>
 
@@ -305,11 +307,40 @@ static Object *get_glyph(ULONG glyph)
 					BITMAP_Width, 16, */
 				BitMapEnd;
 	} else {
-		if((glyph == AVALANCHE_GLYPH_ROOT) || (glyph == AVALANCHE_GLYPH_OPENDRAWER)) glyph = GLYPH_POPDRAWER;
+		if(glyph == AVALANCHE_GLYPH_OPENDRAWER) {
+			struct DrawList opendrawer[] = {
+				{DLST_LINESIZE, 0, 0, 0, 0, 1},	
+				{DLST_LINEPAT, 0, 0, 0, 0, 1},
+								
+				{DLST_LINE, 9, 6, 9, 9, 1},
+				{DLST_LINE, 9, 9, 1, 9, 1},
+				{DLST_LINE, 1, 9, 1, 6, 1},
+				{DLST_LINE, 1, 6, 9, 6, 1},
+				{DLST_LINE, 9, 6, 7, 3, 1},
+				{DLST_LINE, 7, 3, 3, 3, 1},
+				{DLST_LINE, 3, 3, 1, 6, 1},
+				
+				{DLST_LINE, 3, 3, 2, 3, 1},
+				{DLST_LINE, 2, 3, 2, 5, 1},
+
+				{DLST_LINE, 7, 3, 8, 3, 1},
+				{DLST_LINE, 8, 3, 8, 5, 1},
+			
+				{DLST_END, 0, 0, 0, 0, 0},
+			};
 	
-		glyphobj = GlyphObj,
-					GLYPH_Glyph, glyph,
-				GlyphEnd;
+			glyphobj = DrawListObj,
+					DRAWLIST_Directives, &opendrawer,
+					DRAWLIST_RefHeight, 10,
+					DRAWLIST_RefWidth, 10,
+				End;
+		} else {
+			if(glyph == AVALANCHE_GLYPH_ROOT) glyph = GLYPH_POPDRAWER;
+
+			glyphobj = GlyphObj,
+						GLYPH_Glyph, glyph,
+					GlyphEnd;
+		}
 	}
 
 	UnlockPubScreen(NULL, screen);


### PR DESCRIPTION
This PR adds custom glyphs for the "Open dest in WB" button and the archive root image.

This aligns the built-in icons with those when AISS is enabled.

Closes #65 
